### PR TITLE
Mac OS X changes.

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ Please cite our CVPR'10 paper if you use the code for academic purposes.
 } 
 
               
-INSTALATION
+INSTALLATION
 ===========
 
 1. Compile mex files: edit and execute "compile.m"

--- a/README.MAC
+++ b/README.MAC
@@ -1,3 +1,6 @@
+README.MAC
+==========
+
 1.) Make sure the 'OPENCV_HOME' environment variable is set to the directory where OpenCV is installed.
 2.) Verify all paths in compile.m are correct.
 

--- a/README.MAC
+++ b/README.MAC
@@ -1,0 +1,7 @@
+1.) Make sure the 'OPENCV_HOME' environment variable is set to the directory where OpenCV is installed.
+2.) Verify all paths in compile.m are correct.
+
+Tested with:
+- Snow Leopard 10.6.6
+- Matlab 7.11.0.584 (R2010b)
+- gcc 4.2.1

--- a/compile.m
+++ b/compile.m
@@ -18,20 +18,30 @@
 % Compiles mex files.
 clc; clear all; cd mex;
 
-% edit based on your instalation folder
-include = ' -Ic:\OpenCV2.2\include\opencv\ -Ic:\OpenCV2.2\include\';
-libpath = 'C:\OpenCV2.2\CMake\lib\Release\';
+% edit based on your installation folder
+include = [' -I' getenv('OPENCV_HOME') '/include/opencv -I' getenv('OPENCV_HOME') '/include']
+libpath = [getenv('OPENCV_HOME') '/lib/']
 
 % =========================================================================
 
 lib = [];
-files = dir([libpath '*.lib']);
+
+if ismac 
+    libext = '*.dylib';
+    objext = 'tld.o';
+else
+    libext = '*.lib';
+    objext = 'tld.obj';
+end
+
+files = dir([libpath libext]);
 for i = 1:length(files)
     lib = [lib ' ' libpath files(i).name];
 end
+
 eval(['mex lk.cpp -O' include lib]);
 mex -O -c tld.cpp
-mex -O fern.cpp tld.obj
+eval(['mex -O fern.cpp ' objext]);
 mex -O linkagemex.cpp  
 mex -O bb_overlap.cpp  
 mex -O warp.cpp        


### PR DESCRIPTION
Hey Zdenek,

Check out my changes...

Basically, on the Mac, opencv lib extensions are '.dylib' and objects are built as .o not .obj.  I introduced environment variable to provide abstraction.  If the ultimate goal is to move from Matlab to C, then this should provide a good stop gap for the time being.

Cheers,
Bennett 
