### PR TITLE
debian/ubuntu installation of opentld

### DIFF
--- a/compile.m
+++ b/compile.m
@@ -1,4 +1,5 @@
 % Copyright 2011 Zdenek Kalal
+% Copyright 2013 Alois Schloegl
 %
 % This file is part of TLD.
 %
@@ -64,24 +65,25 @@ end
 if isunix
     disp('Unix');
     
-    include = ' -I/usr/local/include/opencv/ -I/usr/local/include/';
-    libpath = '/usr/local/lib/';
+    %include = ' -I/usr/include/opencv/ -I/usr/local/include/';
+    %libpath = '/usr/lib/';
     
-    files = dir([libpath 'libopencv*.so.2.2']);
+    %files = dir([libpath 'libopencv*.so.2.2']);
     
-    lib = [];
-    for i = 1:length(files),
-        lib = [lib ' ' libpath files(i).name];
-    end
+    %lib = [];
+    %for i = 1:length(files),
+    %    lib = [lib ' ' libpath files(i).name];
+    %end
     
-    eval(['mex lk.cpp -O' include lib]);
+    %eval(['mex lk.cpp -O' include lib]);
     mex -O -c tld.cpp
     mex -O fern.cpp tld.o
     mex -O linkagemex.cpp
     mex -O bb_overlap.cpp
     mex -O warp.cpp
     mex -O distance.cpp
-    
+    mex -O lk.cpp -lml -lcv -lcxcore
+
 end
 
 

--- a/mex/lk.backup.cpp
+++ b/mex/lk.backup.cpp
@@ -16,8 +16,8 @@
 // along with TLD.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "mex.h" 
-#include "cv.h"
-#include "highgui.h"
+#include <opencv/cv.h>
+//#include "highgui.h"
 
 IplImage *grey1 = 0, *grey0 = 0, *pyramid1 = 0, *pyramid0 = 0;
 

--- a/mex/lk.cpp
+++ b/mex/lk.cpp
@@ -15,10 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with TLD.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "cv.h"
-#include "highgui.h"
+#include <opencv/cv.h>
+//#include "highgui.h"
 #include "math.h"
 #include <limits>
+#include <stdio.h>
 #ifdef _CHAR16T
 #define CHAR16_T
 #endif


### PR DESCRIPTION
In order to install OpenTLD on debian and ubuntu, I had to apply some minor fixed to the repository. Perhaps you want to merge them into your tree. The mexfile files compiled also fine for octave doing just 
   find ./mex -name *.cpp -exec mkoctfile -mex {} \; 

   Alois

P.S.: as prerequisite, I did 
    sudo apt-get install libcv-dev 
as stated in the install instructions. 
