### PR TITLE
Update img_blur.m

### DIFF
--- a/img/img_blur.m
+++ b/img/img_blur.m
@@ -26,7 +26,7 @@ csize = 6*sigma;
 
 shift = (csize - 1)/2;
 
-h = FSPECIAL('gaussian',csize,sigma);
+h = fspecial('gaussian',csize,sigma);
 
 M = conv2(M,h);
 M = M(1+shift:end-shift,1+shift:end-shift);


### PR DESCRIPTION
MATLAB v >= 2011b are case sensitive with respect to function names, generating an error on FSPECIAL in img_blur.m. It has been changed to the lower-case function name, fspecial.
